### PR TITLE
docs: added <figcaption> element to describe <figure> content

### DIFF
--- a/Cat-Photo-App/index.html
+++ b/Cat-Photo-App/index.html
@@ -60,7 +60,8 @@
                 src="https://cdn.freecodecamp.org/curriculum/cat-photo-app/lasagna.jpg" 
                 alt="A slice of lasagna ona plate."
                 >
-                
+
+                <!-- Элемент <figcaption> используется внутри элемента <figure> для описания (подписи) его содержимого -->
                 <figcaption>Cats love lasagna.</figcaption>
             </figure>
         </section>


### PR DESCRIPTION
- The <figcaption> element is used within the <figure> element to provide a caption for an image.
- This improves the semantic structure of HTML and provides context for the content, which promotes better accessibility.