### PR TITLE
Feat: Add the placeholder attribute to the <input> element

### DIFF
--- a/Cat-Photo-App/index.html
+++ b/Cat-Photo-App/index.html
@@ -98,7 +98,7 @@
                 <!-- Элемент <input> внутри элемента <form> позволяет собирать вводимые пользователем данные для отправки -->
                 <!-- Атрибут name позволяет идентифицировать данные на сервере после отправки формы, 
                     представляет элемент <input> в котором они (данные) собирались. -->
-                <input type="text" name="catphotourl">
+                <input type="text" name="catphotourl" placeholder="cat photo url">
             </form>
         </section>
         </main>


### PR DESCRIPTION
- The 'placeholder' attribute provides guidance to the user on what information to enter (e.g., "Enter your name").
- It appears as grayed-out text inside the input field until the user starts typing.
- This change enhances user experience by making forms more intuitive.